### PR TITLE
fix: color tinting issue

### DIFF
--- a/SCTParser.cpp
+++ b/SCTParser.cpp
@@ -337,8 +337,7 @@ namespace SCTParser {
         image.data = &data_ptr;
 
 
-
-        astcenc_swizzle swizzle = { ASTCENC_SWZ_R, ASTCENC_SWZ_G, ASTCENC_SWZ_B, ASTCENC_SWZ_A };
+        astcenc_swizzle swizzle = { ASTCENC_SWZ_B, ASTCENC_SWZ_G, ASTCENC_SWZ_R, ASTCENC_SWZ_A };
 
 
         status = astcenc_decompress_image(


### PR DESCRIPTION
Looks like the game stores the images in BGRA format and not RGBA.

## Old Output
<img width="180" height="424" alt="img_zero_orb_story_category_circen" src="https://github.com/user-attachments/assets/81bcc3f2-9933-4c6c-a87b-e066f48613fe" />

## New Output
<img width="180" height="424" alt="img_zero_orb_story_category_circen-new" src="https://github.com/user-attachments/assets/86565e59-e875-4a36-9f9b-407b1a570c0b" />
